### PR TITLE
Allow easy access to events from report object

### DIFF
--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -156,7 +156,7 @@ class API(BaseAPI):
 
         if type_ is not None:
             type_ = self._normalize_resource_type(type_)
-            
+
             if title is not None:
                 path = '{0}/{1}'.format(type_, title)
             elif title is None:

--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -189,6 +189,7 @@ class API(BaseAPI):
         reports = self._query('reports', query=query)
         for report in reports:
             yield Report(
+                self,
                 report['certname'],
                 report['hash'],
                 report['start-time'],

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -94,7 +94,7 @@ class Report(object):
     :ivar transaction: UUID identifying this transaction.
 
     """
-    def __init__(self, node, hash_, start, end, received, version,
+    def __init__(self, api, node, hash_, start, end, received, version,
                  format_, agent_version, transaction):
 
         self.node = node
@@ -108,6 +108,8 @@ class Report(object):
         self.run_time = self.end - self.start
         self.transaction = transaction
         self.__string = '{0}'.format(self.hash_)
+        self.__api = api
+        self.__query_scope = '["=", "report", "{0}"]'.format(self.hash_)
 
     def __repr__(self):
         return str('Report: {0}'.format(self.__string))
@@ -117,6 +119,10 @@ class Report(object):
 
     def __unicode__(self):
         return self.__string
+
+    def events(self):
+        """Get all events for this report."""
+        return self.__api.events(self.__query_scope)
 
 
 class Fact(object):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -93,7 +93,7 @@ class TestResource(object):
 class TestReport(object):
     """Test the Report object."""
     def test_report(self):
-        report = Report('node1.puppet.board', 'hash#',
+        report = Report('_', 'node1.puppet.board', 'hash#',
                         '2013-08-01T09:57:00.000Z',
                         '2013-08-01T10:57:00.000Z',
                         '2013-08-01T10:58:00.000Z',
@@ -113,6 +113,7 @@ class TestReport(object):
         assert str(report) == str('hash#')
         assert unicode(report) == unicode('hash#')
         assert repr(report) == str('Report: hash#')
+        assert report._Report__query_scope == '["=", "report", "hash#"]'
 
 
 class TestEvent(object):


### PR DESCRIPTION
Calling Report.events() will return a generator of all the events
belonging to the report.


Example of printing all the events for the last report of node 'node.example.com'
```python
db = pypuppetdb.connect(host='puppetdb')
node = db.node('node.example.com')
for report in node.reports():
    for event in report.events():
        print event
    break
```
---
Practical example from puppetboard
```python
   ...
    reports = puppetdb.reports('["=", "certname", "{0}"]'.format(node))

    for report in reports:
        if report.hash_ == report_id:
            events = report.events()
            return render_template(
                'report.html',
                report=report,
                events=yield_or_stop(events))
```


Let me know if I am on the right track :train2: 