### PR TITLE
Add requires setting to bdist_rpm section of setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,3 +10,4 @@ universal = 1
 
 [bdist_rpm]
 build_requires = python-setuptools
+requires = python-requests


### PR DESCRIPTION
Enables "yum install pypuppetdb" to pull in the other python modules it needs to work