### PR TITLE
Added class, execution path, source file and line number to event items

### DIFF
--- a/pypuppetdb/api/v3.py
+++ b/pypuppetdb/api/v3.py
@@ -218,6 +218,10 @@ class API(BaseAPI):
                 event['new-value'],
                 event['old-value'],
                 event['resource-type'],
+                event['containing-class'],
+                event['containment-path'],
+                event['file'],
+                event['line'],
                 )
 
     def event_counts(self, query, summarize_by,

--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -20,6 +20,11 @@ class Event(object):
     :param new_value: The new value/state of the resource.
     :param old_value: The old value/state of the resource.
     :param type\_: The type of the resource this event fired for.
+    :param class_\_: The class responsible for running this event.
+    :param execution_path: The path used to reach this particular resource.
+    :param source_file: The puppet source code file containing the class.
+    :param line_number: The line number in the source file containing the
+            definition responsible for triggering this event.
 
     :ivar status: A :obj:`string` of this event's status.
     :ivar failed: The :obj:`bool` equivalent of `status`.
@@ -31,7 +36,8 @@ class Event(object):
             event was triggered for.
     """
     def __init__(self, node, status, timestamp, hash_, title, property_,
-                 message, new_value, old_value, type_):
+                 message, new_value, old_value, type_, class_, execution_path,
+                 source_file, line_number):
         self.node = node
         self.status = status
         if self.status == 'failure':
@@ -47,6 +53,10 @@ class Event(object):
         self.item['message'] = message
         self.item['old'] = old_value
         self.item['new'] = new_value
+        self.item['class'] = class_
+        self.item['execution_path'] = execution_path
+        self.item['source_file'] = source_file
+        self.item['line_number'] = line_number
         self.__string = '{0}[{1}]/{2}'.format(self.item['type'],
                                               self.item['title'],
                                               self.hash_)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -120,7 +120,11 @@ class TestEvent(object):
     def test_event(self):
         event = Event('node', 'failure', '2013-08-01T10:57:00.000Z',
                       'hash#', '/etc/ssh/sshd_config', 'ensure',
-                      'Nothing to say', 'present', 'absent', 'file')
+                      'Nothing to say', 'present', 'absent', 'file',
+                      'Ssh::Server',
+                      ['Stage[main]', 'Ssh::Server',
+                       'File[/etc/ssh/sshd_config]'],
+                      '/etc/puppet/modules/ssh/manifests/server.pp', 80)
 
         assert event.node == 'node'
         assert event.status == 'failure'
@@ -140,7 +144,11 @@ class TestEvent(object):
     def test_event_failed(self):
         event = Event('node', 'success', '2013-08-01T10:57:00.000Z',
                       'hash#', '/etc/ssh/sshd_config', 'ensure',
-                      'Nothing to say', 'present', 'absent', 'file')
+                      'Nothing to say', 'present', 'absent', 'file',
+                      'Ssh::Server',
+                      ['Stage[main]', 'Ssh::Server',
+                       'File[/etc/ssh/sshd_config]'],
+                      '/etc/puppet/modules/ssh/manifests/server.pp', 80)
 
         assert event.status == 'success'
         assert event.failed is False


### PR DESCRIPTION
Hello there, here's my first pull request for you :smile: 

This adds some more advanced information to each event which I intend to display on Puppetboard when users are drilling into events and want to know exactly where the problem originated.

e.g.

```python
In [1]: from pypuppetdb import connect

In [2]: db = connect(api_version=3, host='puppetdb', port=8080)

In [3]: events = list(db.events('["=", "report", "5ba5a56b67e05a98bb2dcf9124e74210d7baccbf"]'))                  
In [4]: event = events[0]

In [5]: event.item
Out[5]:
{u'class': u'Jenkins::Builder',
 u'execution_path': [u'Stage[main]',
  u'Jenkins::Builder',
  u'Package[apache2-dev]'],
 u'line_number': 80,
 u'message': u"ensure changed 'purged' to 'latest'",
 u'new': u'latest',
 u'old': u'purged',
 u'property': u'ensure',
 u'source_file': u'/etc/puppet/modules/jenkins/manifests/builder.pp',
 u'title': u'apache2-dev',
 u'type': u'Package'}
```

Cheers
Fotis