### PR TITLE
Implemented optional HTTP basic authentication and url path

### DIFF
--- a/pypuppetdb/__init__.py
+++ b/pypuppetdb/__init__.py
@@ -73,7 +73,8 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 
 def connect(api_version=3, host='localhost', port=8080, ssl_verify=False,
-            ssl_key=None, ssl_cert=None, timeout=10):
+            ssl_key=None, ssl_cert=None, timeout=10, protocol=None,
+            url_path='/', username=None, password=None):
     """Connect with PuppetDB. This will return an object allowing you
     to query the API through its methods.
 
@@ -101,15 +102,34 @@ def connect(api_version=3, host='localhost', port=8080, ssl_verify=False,
     :param timeout: (optional) Number of seconds to wait for a response.
     :type timeout: :obj:`int`
 
+    :param protocol: (optional) Explicitly specify the protocol to be used
+            (especially handy when using HTTPS with ssl_verify=False and
+            without certs)
+    :type protocol: :obj:`None` or :obj:`string`
+
+    :param url_path: (optional) The URL path where PuppetDB is served
+            (if not at the root / path)
+    :type url_path: :obj:`None` or :obj:`string`
+
+    :param username: (optional) The username to use for HTTP basic
+            authentication
+    :type username: :obj:`None` or :obj:`string`
+
+    :param password: (optional) The password to use for HTTP basic
+            authentication
+    :type password: :obj:`None` or :obj:`string`
+
     :raises: :class:`~pypuppetdb.errors.UnsupportedVersionError`
     """
     if api_version == 3:
         return v3.API(host=host, port=port,
                       timeout=timeout, ssl_verify=ssl_verify, ssl_key=ssl_key,
-                      ssl_cert=ssl_cert)
+                      ssl_cert=ssl_cert, protocol=protocol, url_path=url_path,
+                      username=username, password=password)
     if api_version == 2:
         return v2.API(host=host, port=port,
                       timeout=timeout, ssl_verify=ssl_verify, ssl_key=ssl_key,
-                      ssl_cert=ssl_cert)
+                      ssl_cert=ssl_cert, protocol=protocol, url_path=url_path,
+                      username=username, password=password)
     else:
         raise UnsupportedVersionError

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,8 @@
 [pytest]
+addopts = --cov=pypuppetdb --cov-report=term-missing
 norecursedirs = docs .tox
 minversion = 2.3
-markers = 
+markers =
     unit: mark test as a unit test. Runs without PuppetDB.
     integration: mark test as an integration test. Needs a live PuppetDB with testdata loaded.
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,8 @@
 requests==2.1.0
-pytest==2.5.0
+pytest==2.7.0
 mock==1.0.1
 git+https://github.com/gabrielfalcao/HTTPretty.git@python-3.3-support#egg=httpretty
 pytest-pep8==1.0.5
-coverage==3.7
+cov-core==1.15.0
+coverage==3.7.1
+pytest-cov==1.8.1


### PR DESCRIPTION
Hey there,

In several environments (like ours), we place PuppetDB behind haproxy with authentication (others may use Nginx or Apache).  We're also serving this at the URL http://www.example.com/puppetdb/ which we need to support.

While doing this, I also updated py.test and setup coverage reporting for the unit tests :smile: 

Cheers
Fotis