### PR TITLE
Fix: report correct failed node status

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -398,6 +398,8 @@ class BaseAPI(object):
                         node['status'] = 'noop'
                     if status['failures'] > 0:
                         node['status'] = 'failed'
+                elif node['latest_report_status'] == 'failed':
+                    node['status'] = 'failed'
                 else:
                     node['status'] = 'unchanged'
 


### PR DESCRIPTION
Consider a failed report and not just failed events to decide a nodes' failed status.

This was especially confusing with current puppetboard as failed nodes without events would not be listed on the overview page as failed.