### PR TITLE
Use node['latest_report_status'] when available

### DIFF
--- a/pypuppetdb/api/__init__.py
+++ b/pypuppetdb/api/__init__.py
@@ -401,6 +401,10 @@ class BaseAPI(object):
                 else:
                     node['status'] = 'unchanged'
 
+                # Override if available
+                if 'latest_report_status' in node:
+                    node['status'] = node['latest_report_status']
+
                 # node report age
                 if node['report_timestamp'] is not None:
                     try:


### PR DESCRIPTION
This is not just faster, it's more accurate, as it will report catalog compilations failures as failures, too.