### PR TITLE
pypuppetdb/utils: Adding a new utility function versioncmp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 #########
 
+0.2.1
+=====
+
+* Adding a version comparison utility function using examples provided in
+  http://stackoverflow.com/questions/1714027/version-number-comparison
+
 0.2.0
 =====
 

--- a/pypuppetdb/utils.py
+++ b/pypuppetdb/utils.py
@@ -47,4 +47,7 @@ def json_to_datetime(date):
 def versioncmp(v1, v2):
     def normalize(v):
         return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
-    return cmp(normalize(v1), normalize(v2))
+    try:
+        return cmp(normalize(v1), normalize(v2))
+    except NameError:
+        return (v1 > v2) - (v1 < v2)

--- a/pypuppetdb/utils.py
+++ b/pypuppetdb/utils.py
@@ -50,4 +50,5 @@ def versioncmp(v1, v2):
     try:
         return cmp(normalize(v1), normalize(v2))
     except NameError:
-        return (v1 > v2) - (v1 < v2)
+        return (normalize(v1) > normalize(v2)) - (
+            normalize(v1) < normalize(v2))

--- a/pypuppetdb/utils.py
+++ b/pypuppetdb/utils.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import warnings
 import datetime
+import re
 
 
 # A UTC class, see:
@@ -41,3 +42,9 @@ def json_to_datetime(date):
     """
     return datetime.datetime.strptime(date, '%Y-%m-%dT%H:%M:%S.%fZ').replace(
         tzinfo=UTC())
+
+
+def versioncmp(v1, v2):
+    def normalize(v):
+        return [int(x) for x in re.sub(r'(\.0+)*$', '', v).split(".")]
+    return cmp(normalize(v1), normalize(v2))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,3 +47,25 @@ class TestJSONToDateTime(object):
     def test_json_to_datetime_invalid(self):
         with pytest.raises(ValueError):
             pypuppetdb.utils.json_to_datetime('2013-08-0109:57:00.000Z')
+
+
+class TestVersionCmp(object):
+    """Test the versioncmp function using different criteria."""
+
+    def test_versioncmp(self):
+        assert pypuppetdb.utils.versioncmp('1', '1') == 0
+        assert pypuppetdb.utils.versioncmp('2.1', '2.2') < 0
+        assert pypuppetdb.utils.versioncmp('3.0.4.10', '3.0.4.2') > 0
+        assert pypuppetdb.utils.versioncmp('4.08', '4.08.1') < 0
+        assert pypuppetdb.utils.versioncmp('3.2.1.9.8144', '3.2') > 0
+        assert pypuppetdb.utils.versioncmp('3.2', '3.2.1.9.8144') < 0
+        assert pypuppetdb.utils.versioncmp('1.2', '2.1') < 0
+        assert pypuppetdb.utils.versioncmp('2.1', '1.2') > 0
+        assert pypuppetdb.utils.versioncmp('5.6.7', '5.6.7') == 0
+        assert pypuppetdb.utils.versioncmp('1.01.1', '1.1.1') == 0
+        assert pypuppetdb.utils.versioncmp('1.1.1', '1.01.1') == 0
+        assert pypuppetdb.utils.versioncmp('1', '1.0') == 0
+        assert pypuppetdb.utils.versioncmp('1.0', '1') == 0
+        assert pypuppetdb.utils.versioncmp('1.0', '1.0.1') < 0
+        assert pypuppetdb.utils.versioncmp('1.0.1', '1.0') > 0
+        assert pypuppetdb.utils.versioncmp('1.0.2.0', '1.0.2') == 0


### PR DESCRIPTION
As the name suggests it provides a standard way for pypuppetdb code
ro run standard version comparisons. This function is built off the examples and tests provided in http://stackoverflow.com/questions/1714027/version-number-comparison

The initial intent of this function was to check the Version of PuppetDB
running and check if it is version 3.0 or higher and throw an error
if it failed. In attempting to do so I broke all existing automated
test cases, will have to implement that check in a different way.