### PR TITLE
pypuppetdb: Adding support for new features available in 3.2.0

### DIFF
--- a/pypuppetdb/types.py
+++ b/pypuppetdb/types.py
@@ -319,6 +319,9 @@ class Node(object):
     :param facts_environment: (default 'production') The environment of the\
             last received fact set for this node
     :type facts_environment" :obj:`string`
+    :param latest_report_hash: The hash of the latest report from this node,\
+            is only available in PuppetDB 3.2 and later
+    :type latest_report_hash: :obj:`string`
 
     :ivar name: Hostname of this node.
     :ivar deactivated: :obj:`datetime.datetime` when this host was\
@@ -333,15 +336,19 @@ class Node(object):
             received report for this node.
     :ivar catalog_environment: :obj:`string` the environment of the last\
             received catalog for this node.
-    :ivar facts_environment: :obj:`string` the environemtn of the last\
+    :ivar facts_environment: :obj:`string` the environment of the last\
             received fact set for this node.
+    :ivar latest_report_hash: :obj:`string` the hash value of the latest\
+            report the current node reported. Available in PuppetDB 3.2\
+            and later.
     """
     def __init__(self, api, name, deactivated=None, expired=None,
                  report_timestamp=None, catalog_timestamp=None,
                  facts_timestamp=None, status=None, events=None,
                  unreported_time=None, report_environment='production',
                  catalog_environment='production',
-                 facts_environment='production'):
+                 facts_environment='production',
+                 latest_report_hash=None):
         self.name = name
         self.status = status
         self.events = events
@@ -352,6 +359,7 @@ class Node(object):
         self.report_environment = report_environment
         self.catalog_environment = catalog_environment
         self.facts_environment = facts_environment
+        self.latest_report_hash = latest_report_hash
 
         if deactivated is not None:
             self.deactivated = json_to_datetime(deactivated)
@@ -453,6 +461,9 @@ class Catalog(object):
     :param environment: The environment associated with the catalog's\
         certname.
     :type environment: :obj:`string`
+    :param code_id: The string used to tie this catalog to the Puppet code\
+        which generated the catalog.
+    :type code_id: :obj:`string`
 
     :ivar node: :obj:`string` Name of the host
     :ivar version: :obj:`string` Catalog version from Puppet
@@ -465,14 +476,17 @@ class Catalog(object):
         Resource object of the relationship
     :ivar environment: :obj:`string` Environment associated with the
         catalog's certname
+    :ivar code_id: :obj:`string` ties the catalog to the Puppet code that\
+        generated the catalog
     """
     def __init__(self, node, edges, resources, version, transaction_uuid,
-                 environment=None):
+                 environment=None, code_id=None):
 
         self.node = node
         self.version = version
         self.transaction_uuid = transaction_uuid
         self.environment = environment
+        self.code_id = code_id
 
         self.resources = dict()
         for resource in resources:

--- a/tests/test_baseapi.py
+++ b/tests/test_baseapi.py
@@ -307,6 +307,16 @@ class TesteAPIQuery(object):
         baseapi._query('nodes', include_total=True)
         assert baseapi.total == 256
 
+    def test_query_bad_request_type(self, baseapi):
+        httpretty.enable()
+        stub_request('http://localhost:8080/pdb/query/v4/nodes')
+        with pytest.raises(pypuppetdb.errors.APIError):
+            baseapi._query('nodes',
+                           query='["certname", "=", "node1"]',
+                           request_method='DELETE')
+        httpretty.disable()
+        httpretty.reset()
+
 
 class TestAPIMethods(object):
     def test_metric(self, baseapi):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -98,6 +98,12 @@ class TestNode(object):
         assert unicode(node) == unicode('node')
         assert repr(node) == str('<Node: node>')
 
+    def test_with_latest_report_hash(self):
+        node = Node('_', 'node',
+                    latest_report_hash='hash#1')
+        assert node.name == 'node'
+        assert node.latest_report_hash == 'hash#1'
+
 
 class TestFact(object):
     """Test the Fact object."""
@@ -248,6 +254,20 @@ class TestCatalog(object):
         assert unicode(catalog) == unicode('node/None')
         assert repr(catalog) == str(
             '<Catalog: node/None>')
+
+    def test_catalog_codeid(self):
+        catalog = Catalog('node', [], [], 'unique', None,
+                          code_id='somecodeid')
+        assert catalog.node == 'node'
+        assert catalog.version == 'unique'
+        assert catalog.transaction_uuid is None
+        assert catalog.resources == {}
+        assert catalog.edges == []
+        assert str(catalog) == str('node/None')
+        assert unicode(catalog) == unicode('node/None')
+        assert repr(catalog) == str(
+            '<Catalog: node/None>')
+        assert catalog.code_id == 'somecodeid'
 
 
 class TestEdge(object):


### PR DESCRIPTION
Fixed https://github.com/puppet-community/pypuppetdb/issues/60

The Nodes endpoint now has available a latest_report_status and a latest_report_hash
strings to easily tie it to it's latest report. The latest_report_status
key does not report on noop runs and setting latest_report_hash to a default
None to maintain backward compatability.

The Catalogs endpoint exposes a 'code_id' field that is current unused
but will be used to tie a catalog to the Puppet code that generated the
catalog.

All endpoints now support POST requests. Adding a test case testing against
a DELETE request (non-GET or non-POST requests raise an APIError). Could
not make a test case testing specifically against a POST method in the
last request.